### PR TITLE
Resource 'aws_db_instance.mariadb' does not have attribute 'port'

### DIFF
--- a/aws-rds-db_instances.tf
+++ b/aws-rds-db_instances.tf
@@ -10,7 +10,7 @@ resource "aws_db_instance" "mariadb" {
   storage_type      = "gp2"
   allocated_storage = "10"
   
-  port                    = "3306"
+  port                    = 3306
   multi_az                = "false"
   availability_zone       = "eu-west-1a"
   publicly_accessible     = "true"


### PR DESCRIPTION
Error running plan: 1 error(s) occurred:

* Resource 'aws_db_instance.mariadb' does not have attribute 'port' for variable 'aws_db_instance.mariadb.port'